### PR TITLE
Force installation of the correct systick handler.

### DIFF
--- a/source/arch/sys_arch.c
+++ b/source/arch/sys_arch.c
@@ -46,6 +46,7 @@ void SysTick_Init(void) {
     if (SysTick_Config(SystemCoreClock / 1000)) {
         while (1);     /* Capture error */
     }
+	NVIC_SetVector(SysTick_IRQn,&SysTick_Handler);
 }
 
 /** \brief  SysTick IRQ handler and timebase management


### PR DESCRIPTION
Possible fix for hang in osDelay
