### PR TITLE
Set socket::impl to null to prevent double free

### DIFF
--- a/source/asynch_socket.c
+++ b/source/asynch_socket.c
@@ -273,7 +273,7 @@ static socket_error_t lwipv4_socket_accept(struct socket *sock, socket_api_handl
 static socket_error_t lwipv4_socket_close(struct socket *sock)
 {
     err_t err = ERR_OK;
-    if (sock == NULL)
+    if (sock == NULL || sock->impl == NULL)
         return SOCKET_ERROR_NULL_PTR;
     switch (sock->family) {
     case SOCKET_DGRAM:
@@ -289,7 +289,7 @@ static socket_error_t lwipv4_socket_close(struct socket *sock)
 }
 static void lwipv4_socket_abort(struct socket *sock)
 {
-    if (sock == NULL)
+    if (sock == NULL || sock->impl == NULL)
         return;
     switch (sock->family) {
     case SOCKET_DGRAM:
@@ -528,6 +528,8 @@ err_t irqTCPRecv(void * arg, struct tcp_pcb * tpcb, struct pbuf * p, err_t err)
         s->event = &e;
         ((socket_api_handler_t) (s->handler))();
         s->event = NULL;
+        /* Zero the impl, since a disconnect will cause a free */
+        s->impl = NULL;
         return ERR_OK;
     }
     w = rx_core(s, p);


### PR DESCRIPTION
Socket::impl set to NULL in onDisconnect to prevent double free from happening.  onDisconnect is only called just before the free occurs, so this should be safe.
