### PR TITLE
Remove mbed dependency, add mbed-core test-dependency.

### DIFF
--- a/module.json
+++ b/module.json
@@ -28,14 +28,16 @@
     "mbed-net-lwip/lwip/include/netif"
   ],
   "dependencies": {
-    "mbed": "*",
     "mbed-net-socket-abstract": "~0.1.1"
   },
   "targetDependencies": {
-    "lwip-k64f": {
+    "k64f": {
       "mbed-net-lwip-k64f": "~0.0.4",
       "mbed-net-lwip-eth": "~0.0.3"
     }
+  },
+  "testDependencies": {
+    "mbed-core": "~0.2.4"
   },
   "scripts": {
     "testReporter": [


### PR DESCRIPTION
Remove lwip-k64f targetDependency and replace with k64f since lwip is implicit in mbed-net-lwip.

@bogdanm 
