### PR TITLE
Fix a disconnect race condition

### DIFF
--- a/source/asynch_socket.c
+++ b/source/asynch_socket.c
@@ -511,7 +511,6 @@ void irqUDPRecv(void * arg, struct udp_pcb * upcb,
 
 err_t irqTCPRecv(void * arg, struct tcp_pcb * tpcb, struct pbuf * p, err_t err)
 {
-    (void) tpcb;
     struct socket_event e;
     struct socket *s = (struct socket *) arg;
 
@@ -529,8 +528,17 @@ err_t irqTCPRecv(void * arg, struct tcp_pcb * tpcb, struct pbuf * p, err_t err)
         s->event = &e;
         ((socket_api_handler_t) (s->handler))();
         s->event = NULL;
-        /* Zero the impl, since a disconnect will cause a free */
-        s->impl = NULL;
+        /* if close has been called, we have to remove impl, since it could be freed */
+        switch (tpcb->state) {
+            case FIN_WAIT_1:
+            case FIN_WAIT_2:
+            case TIME_WAIT:
+                /* Zero the impl, since a disconnect will cause a free */
+                s->impl = NULL;
+                break;
+            default:
+                break;
+        }
         return ERR_OK;
     }
 


### PR DESCRIPTION
It is not always safe to zero the socket stack pointer. Check the state of the protocol control buffer before zeroing.

cc @bogdanm @niklas-arm @0xc0170 @LiyouZhou @lws-team