### PR TITLE
Added working versions of init_api, tcp_echo_client and udp_echo_client_test

### DIFF
--- a/ci/sal_stack_lwip_ci.py
+++ b/ci/sal_stack_lwip_ci.py
@@ -3,28 +3,17 @@
 """
 ##############################################################################
 # sa_stack_lwip_ci.py
-#  CI (noclone) automation script to invoke sal-test module testing.
+#  CI (noclone) automation script to invoke sal-stack-lwip module testing.
 #
 # This script overcomes the following problems:
-# - sal-test is dependent on changes in the sal-stack-lwip module that 
-#   havent been published in the yotta registry. Thus when sal-test
+# - sal-stack-lwip is dependent on changes in the sal-stack-lwip module that 
+#   havent been published in the yotta registry. Thus when sal-stack-lwip
 #   builds with the yotta published version the build would break. This
 #   is overcome by git cloning sal-stack-lwip (to get HEAD with changes)
-#   and using yt link in sal-test to use that version of sal-stack-lwip.
-#
-# In summary, this is what the script is doing
-#   $ git clone git@github.com:/ARMmbed/sal-test.git sal-test
-#   $ git clone git@github.com:/ARMmbed/sal-stack-lwip.git sal-stack-lwip_fixup
-#   $ pushd sal-stack-lwip_fixup
-#   $ yt link
-#   $ popd
-#   $ pushd sal-test
-#   $ yt link sal-stack-lwip_fixup
-#   $ yt target frdm-k64f-gcc
-#   $ yt build
+#   and using yt link in sal-stack-lwip to use that version of sal-stack-lwip.
 #
 # Example usage: 
-#     $ sal_test_ci.py 
+#     $ sal_stacl_lwip_ci.py 
 #
 # Author: simon.hughes@arm.com
 ###############################################################################
@@ -42,8 +31,8 @@ MBED_SUCCESS = 0
 MBED_FAILURE = 1
 MBED_ERROR_MAX = 2
 
-g_debug = True
-#g_debug = False
+#g_debug = True
+g_debug = False
 
 # a debug trace function
 def dbg(str):
@@ -124,108 +113,10 @@ class sal_test:
 
         return ret
 
-
-    def sal_stack_lwip_symlink(self):
-        ret = MBED_FAILURE
-
-        dbg(sys._getframe().f_code.co_name + ":entered")
-        dbg(sys._getframe().f_code.co_name + ":ret=" + str(ret))
-        
-        # note the use of backslash as the file separator
-        bashCommand = "pushd sal-stack-lwip\yotta_modules && mv sal sal_" + self.datestamp + " && junction.exe sal ../../sal && popd"
-        ret = self.doBashCmd(bashCommand)
-        if ret != MBED_SUCCESS:
-            dbg(sys._getframe().f_code.co_name + ": failed to yotta link sal.") 
-            return ret;
-    
-        return ret
-
-    def sal_stack_lwip_unsymlink(self):
-        ret = MBED_FAILURE
-
-        dbg(sys._getframe().f_code.co_name + ":entered")
-        dbg(sys._getframe().f_code.co_name + ":ret=" + str(ret))
-        
-        bashCommand = "pushd sal-stack-lwip/yotta_modules && junction.exe -d sal" 
-        ret = self.doBashCmd(bashCommand)
-        if ret != MBED_SUCCESS:
-            dbg(sys._getframe().f_code.co_name + ": failed to yotta link sal-stack-lwip.") 
-            return ret;
- 
-        return ret
-
-
     ##############################################################################
     # FUNCTION: run()
     #  this is the main function that implements the functionality
     ##############################################################################
-		     
-    def run_old(self, args):
-        ret = MBED_FAILURE
-
-        dbg(sys._getframe().f_code.co_name + ":entered")
-        dbg(sys._getframe().f_code.co_name + ":ret=" + str(ret))
-        
-        
-        # CI (i.e. jenkins) is setup to clone the sal-test and sal-stack-lwip repos so
-        # the cloning of the repos is not required. The noclone option allows the 
-        # cloning of the repos to be skipped
-        if args.noclone is False:
-            # e.g. running outside of noclone so dont clone repositories
-        
-            bashCommand = "git clone git@github.com:/simonqhughes/sal.git sal" 
-            ret = self.doBashCmd(bashCommand)
-            if ret != MBED_SUCCESS:
-                dbg(sys._getframe().f_code.co_name + ": failed to clone sal repo.") 
-                return ret;
-                
-            bashCommand = "git clone git@github.com:/simonqhughes/sal-stack-lwip.git sal-stack-lwip" 
-            ret = self.doBashCmd(bashCommand)
-            if ret != MBED_SUCCESS:
-                dbg(sys._getframe().f_code.co_name + ": failed to clone sal-stack-lwip repo.") 
-                return ret
-
-        # set the target first as this is required by other commands.
-        bashCommand = "pushd sal-stack-lwip && yotta target frdm-k64f-gcc && popd" 
-        ret = self.doBashCmd(bashCommand)
-        if ret != MBED_SUCCESS:
-            dbg(sys._getframe().f_code.co_name + ": failed to set yotta target.") 
-            return ret
-
-        bashCommand = "pushd sal-stack-lwip && yotta -t frdm-k64f-gcc install && popd" 
-        ret = self.doBashCmd(bashCommand)
-        if ret != MBED_SUCCESS:
-            dbg(sys._getframe().f_code.co_name + ": failed to yotta install in pushd sal-stack-lwip.") 
-            return ret
-
-        ret = self.sal_stack_lwip_symlink()
-        if ret != MBED_SUCCESS:
-            return ret
-            
-        bashCommand = "pushd sal-stack-lwip && yotta list && popd" 
-        ret = self.doBashCmd(bashCommand)
-        if ret != MBED_SUCCESS:
-            dbg(sys._getframe().f_code.co_name + ": failed to yotta list in sal.")
-            self.sal_stack_lwip_unsymlink()
-            return ret
-
-        bashCommand = "pushd sal-stack-lwip && yotta build && popd" 
-        ret = self.doBashCmd(bashCommand)
-        if ret != MBED_SUCCESS:
-            dbg(sys._getframe().f_code.co_name + ": failed to yotta build.") 
-            self.sal_stack_lwip_unsymlink()
-            return ret
-
-        bashCommand = "pushd sal-stack-lwip && mbedgt -V && popd" 
-        ret = self.doBashCmd(bashCommand)
-        if ret != MBED_SUCCESS:
-            dbg(sys._getframe().f_code.co_name + ": failed to yotta build.") 
-            self.sal_stack_lwip_unsymlink()
-            return ret
-
-        ret = self.sal_stack_lwip_unsymlink()
-        if ret != MBED_SUCCESS:
-            return ret
 
     def run(self, args):
         ret = MBED_FAILURE
@@ -288,19 +179,11 @@ class sal_test:
             self.sal_stack_lwip_unsymlink()
             return ret
 
-        #bashCommand = "pushd sal-stack-lwip && mbedgt -V && popd" 
-        #ret = self.doBashCmd(bashCommand)
-        #if ret != MBED_SUCCESS:
-        #    dbg(sys._getframe().f_code.co_name + ": failed to yotta build.") 
-        #    self.sal_stack_lwip_unsymlink()
-        #    return ret
-
+        # dont invoke greentea testing here
         self.sal_yt_unlink()
         self.sal_stack_lwip_yt_unlink()
-
         return ret
         
-
 
 if __name__ == "__main__":
 

--- a/ci/sal_stack_lwip_ci.py
+++ b/ci/sal_stack_lwip_ci.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+
+"""
+##############################################################################
+# sa_stack_lwip_ci.py
+#  CI (noclone) automation script to invoke sal-test module testing.
+#
+# This script overcomes the following problems:
+# - sal-test is dependent on changes in the sal-stack-lwip module that 
+#   havent been published in the yotta registry. Thus when sal-test
+#   builds with the yotta published version the build would break. This
+#   is overcome by git cloning sal-stack-lwip (to get HEAD with changes)
+#   and using yt link in sal-test to use that version of sal-stack-lwip.
+#
+# In summary, this is what the script is doing
+#   $ git clone git@github.com:/ARMmbed/sal-test.git sal-test
+#   $ git clone git@github.com:/ARMmbed/sal-stack-lwip.git sal-stack-lwip_fixup
+#   $ pushd sal-stack-lwip_fixup
+#   $ yt link
+#   $ popd
+#   $ pushd sal-test
+#   $ yt link sal-stack-lwip_fixup
+#   $ yt target frdm-k64f-gcc
+#   $ yt build
+#
+# Example usage: 
+#     $ sal_test_ci.py 
+#
+# Author: simon.hughes@arm.com
+###############################################################################
+"""
+
+import subprocess
+import argparse
+import sys
+import os      
+import time
+import datetime
+
+# error codes are positive numbers because sys.exit() returns a +ve number to the env
+MBED_SUCCESS = 0
+MBED_FAILURE = 1
+MBED_ERROR_MAX = 2
+
+g_debug = True
+#g_debug = False
+
+# a debug trace function
+def dbg(str):
+    if g_debug:
+        print str
+    return
+
+
+##############################################################################
+# sal_test
+##############################################################################
+class sal_test:
+    """A class to manage the test"""
+
+    def __init__(self):
+        ts = time.time()
+        self.datestamp = datetime.datetime.fromtimestamp(ts).strftime('%Y%m%d_%H%M%S')
+
+    # function to execute a bash command
+    def doBashCmd(self, strBashCommand):
+        ret = subprocess.call(strBashCommand.split(), shell=True)
+        return ret
+
+    def sal_stack_lwip_symlink(self):
+        ret = MBED_FAILURE
+
+        dbg(sys._getframe().f_code.co_name + ":entered")
+        dbg(sys._getframe().f_code.co_name + ":ret=" + str(ret))
+        
+        # note the use of backslash as the file separator
+        bashCommand = "pushd sal-stack-lwip\yotta_modules && mv sal sal_" + self.datestamp + " && junction.exe sal ../../sal && popd"
+        ret = self.doBashCmd(bashCommand)
+        if ret != MBED_SUCCESS:
+            dbg(sys._getframe().f_code.co_name + ": failed to yotta link sal.") 
+            return ret;
+    
+        return ret
+
+    def sal_stack_lwip_unsymlink(self):
+        ret = MBED_FAILURE
+
+        dbg(sys._getframe().f_code.co_name + ":entered")
+        dbg(sys._getframe().f_code.co_name + ":ret=" + str(ret))
+        
+        bashCommand = "pushd sal-stack-lwip/yotta_modules && junction.exe -d sal" 
+        ret = self.doBashCmd(bashCommand)
+        if ret != MBED_SUCCESS:
+            dbg(sys._getframe().f_code.co_name + ": failed to yotta link sal-stack-lwip.") 
+            return ret;
+ 
+        return ret
+
+
+    ##############################################################################
+    # FUNCTION: run()
+    #  this is the main function that implements the functionality
+    ##############################################################################
+		     
+    def run(self, args):
+        ret = MBED_FAILURE
+
+        dbg(sys._getframe().f_code.co_name + ":entered")
+        dbg(sys._getframe().f_code.co_name + ":ret=" + str(ret))
+        
+        
+        # CI (i.e. jenkins) is setup to clone the sal-test and sal-stack-lwip repos so
+        # the cloning of the repos is not required. The noclone option allows the 
+        # cloning of the repos to be skipped
+        if args.noclone is False:
+            # e.g. running outside of noclone so dont clone repositories
+        
+            bashCommand = "git clone git@github.com:/simonqhughes/sal.git sal" 
+            ret = self.doBashCmd(bashCommand)
+            if ret != MBED_SUCCESS:
+                dbg(sys._getframe().f_code.co_name + ": failed to clone sal repo.") 
+                return ret;
+                
+            bashCommand = "git clone git@github.com:/simonqhughes/sal-stack-lwip.git sal-stack-lwip" 
+            ret = self.doBashCmd(bashCommand)
+            if ret != MBED_SUCCESS:
+                dbg(sys._getframe().f_code.co_name + ": failed to clone sal-stack-lwip repo.") 
+                return ret
+
+        # set the target first as this is required by other commands.
+        bashCommand = "pushd sal-stack-lwip && yotta target frdm-k64f-gcc && popd" 
+        ret = self.doBashCmd(bashCommand)
+        if ret != MBED_SUCCESS:
+            dbg(sys._getframe().f_code.co_name + ": failed to set yotta target.") 
+            return ret
+
+        bashCommand = "pushd sal-stack-lwip && yotta -t frdm-k64f-gcc install && popd" 
+        ret = self.doBashCmd(bashCommand)
+        if ret != MBED_SUCCESS:
+            dbg(sys._getframe().f_code.co_name + ": failed to yotta install in pushd sal-stack-lwip.") 
+            return ret
+
+        ret = self.sal_stack_lwip_symlink()
+        if ret != MBED_SUCCESS:
+            return ret
+            
+        bashCommand = "pushd sal-stack-lwip && yotta list && popd" 
+        ret = self.doBashCmd(bashCommand)
+        if ret != MBED_SUCCESS:
+            dbg(sys._getframe().f_code.co_name + ": failed to yotta list in sal.")
+            self.sal_stack_lwip_unsymlink()
+            return ret
+
+        bashCommand = "pushd sal-stack-lwip && yotta build && popd" 
+        ret = self.doBashCmd(bashCommand)
+        if ret != MBED_SUCCESS:
+            dbg(sys._getframe().f_code.co_name + ": failed to yotta build.") 
+            self.sal_stack_lwip_unsymlink()
+            return ret
+
+        bashCommand = "pushd sal-stack-lwip && yotta build && popd" 
+        ret = self.doBashCmd(bashCommand)
+        if ret != MBED_SUCCESS:
+            dbg(sys._getframe().f_code.co_name + ": failed to yotta build.") 
+            self.sal_stack_lwip_unsymlink()
+            return ret
+
+        bashCommand = "pushd sal-stack-lwip && mbedgt -V && popd" 
+        ret = self.doBashCmd(bashCommand)
+        if ret != MBED_SUCCESS:
+            dbg(sys._getframe().f_code.co_name + ": failed to yotta build.") 
+            self.sal_stack_lwip_unsymlink()
+            return ret
+
+        ret = self.sal_stack_lwip_unsymlink()
+        if ret != MBED_SUCCESS:
+            return ret
+
+if __name__ == "__main__":
+
+    ret = MBED_FAILURE
+    test = sal_test()
+
+    # command line argment setup and parsing
+    parser = argparse.ArgumentParser()
+    # noclone options. todo: will be used when develop
+    parser.add_argument('--noclone', action='store_true', help='using this option => no clones of sal and sal-stack-lwip dirs')
+    args = parser.parse_args()
+    ret = test.run(args)
+    sys.exit(ret)
+
+
+    
+
+
+
+

--- a/ci/sal_stack_lwip_ci.py
+++ b/ci/sal_stack_lwip_ci.py
@@ -288,12 +288,12 @@ class sal_test:
             self.sal_stack_lwip_unsymlink()
             return ret
 
-        bashCommand = "pushd sal-stack-lwip && mbedgt -V && popd" 
-        ret = self.doBashCmd(bashCommand)
-        if ret != MBED_SUCCESS:
-            dbg(sys._getframe().f_code.co_name + ": failed to yotta build.") 
-            self.sal_stack_lwip_unsymlink()
-            return ret
+        #bashCommand = "pushd sal-stack-lwip && mbedgt -V && popd" 
+        #ret = self.doBashCmd(bashCommand)
+        #if ret != MBED_SUCCESS:
+        #    dbg(sys._getframe().f_code.co_name + ": failed to yotta build.") 
+        #    self.sal_stack_lwip_unsymlink()
+        #    return ret
 
         self.sal_yt_unlink()
         self.sal_stack_lwip_yt_unlink()

--- a/test/host_tests/sal_tcpclient.py
+++ b/test/host_tests/sal_tcpclient.py
@@ -47,7 +47,7 @@ class SalTcpClientTest(BaseHostTest):
         s.connect((ipaddrs, port))
         
         tx_data = "1234567890abcdef"
-        for i in xrange(7):
+        for i in xrange(8):
             s.send(tx_data)
             print "Host: sent %u bytes of data" % len(tx_data)
             rx_data = s.recv(len(tx_data))

--- a/test/host_tests/sal_tcpclient.py
+++ b/test/host_tests/sal_tcpclient.py
@@ -1,0 +1,110 @@
+"""
+mbed OS
+Copyright (c) 2011-2016 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import socket
+import time
+import threading
+import re
+from mbed_host_tests import BaseHostTest
+
+
+class SalTcpClientTest(BaseHostTest):
+    """
+    mbed greentea framework host test script for tcp_echo_server client 
+    side functionality. The test does the following:
+      - Receives over the serial port the target ipaddr, port of the 
+        target tcp server
+      - establishes a connection with the remoted tcp echo server
+      - sends ever increasing data buffers using send() starting with
+        a 16 byte buffer and doubling the size of the data sent on each 
+        iteration through the loop. 
+      - When finished, a command is send to the remote tcp server to 
+        cause it to terminate. 
+    """
+
+    name = 'sal_tcpclient'
+
+    def tcp_client_tx_rx(self, ipaddrs, port):
+        "Thread entrypoint for sending and receiving data to/from the remote tcp echo server."
+      
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("", 0))
+        s.connect((ipaddrs, port))
+        
+        tx_data = "1234567890abcdef"
+        for i in xrange(7):
+            s.send(tx_data)
+            print "Host: sent %u bytes of data" % len(tx_data)
+            rx_data = s.recv(len(tx_data))
+            tx_data += tx_data
+            print "Host: recevied %u bytes of data" % len(rx_data)
+
+        # command to get the remove tcp server to terminate
+        data = "quit"
+        s.send(data)
+        # let remote target terminate the tcp connection
+        while True:
+            data = s.recv(1024)
+            if not data: 
+                break
+        s.close()
+
+        
+    def test(self, selftest):
+        # Returning none will suppress host test from printing success code
+        """ main greentea host test script entry point which implements the functionality of the test as described above."""
+        
+        # mbed greentea framwork support the following for outputing serial console emitted 
+        # from the target, but it doesnt work relibly for me.
+        # selftest.dump_serial()
+        # selftest.dump_serial_end()
+        
+        # until its fixed, the following emits the serial console trace
+        while True:
+            c = selftest.mbed.serial_readline()
+            if c is None:
+                selftest.print_result(self.RESULT_IO_SERIAL)
+                return
+            
+            print "MBED: " + c.strip()
+            
+            # look for the end tag in serial output denoting the test has 
+            # finished, and this can return.
+            if c.strip() == "{{end}}":
+                print "HOST: Terminating Test"
+                break
+            
+            # find remote tcp server IP address in serial console stream:
+            elif ">>> EC" in c.strip():
+                # The ipddress is embedded in a string of the form ">>> EC,w.x.y.z,port_num"
+                # extract the ipaddress and tx/rx packets to/from the target tcp server
+
+                find_string = ">>> EC,"
+                ip = re.findall(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", c.strip())
+                srv_ipaddrs = str(ip[0])
+                print srv_ipaddrs
+                port = c.strip().replace(find_string, "", 1)
+                port = port.replace(str(ip[0])+",", "", 1)
+                print str(port)
+                srv_port = int(port)
+                print "HOST: target reported tcp server: %s:%d" %(srv_ipaddrs, srv_port)
+                
+                self.tcp_client_thread = threading.Thread(target=self.tcp_client_tx_rx, args=(srv_ipaddrs, srv_port))
+                self.tcp_client_thread.start()
+
+  

--- a/test/host_tests/sal_tcpclient.py
+++ b/test/host_tests/sal_tcpclient.py
@@ -24,6 +24,16 @@ from mbed_host_tests import BaseHostTest
 
 
 class SalTcpClientTest(BaseHostTest):
+    # The test loops through a sending/receiving data. On loop i the 
+    # test send 2^(4+i) bytes where i = {0, 1, ... TX_LOOP_MAX}
+    # This is intended to be a data channel functional test rather than a 
+    # stress test so the max tx data length of 4096 bytes is appropriate. 
+    TX_LOOP_MAX = 8
+    # This is the maximum receive size used throught the sal-stack-lwip tests.
+    # Tests are intended to be functional tests rather than stress test, and 
+    # the maximum tx data length is currently 8192. 
+    RX_SIZE_MAX=8192
+
     """
     mbed greentea framework host test script for tcp_echo_server client 
     side functionality. The test does the following:
@@ -43,11 +53,10 @@ class SalTcpClientTest(BaseHostTest):
         "Thread entrypoint for sending and receiving data to/from the remote tcp echo server."
       
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("", 0))
         s.connect((ipaddrs, port))
         
         tx_data = "1234567890abcdef"
-        for i in xrange(8):
+        for i in xrange(self.TX_LOOP_MAX):
             s.send(tx_data)
             print "Host: sent %u bytes of data" % len(tx_data)
             rx_data = s.recv(len(tx_data))
@@ -59,7 +68,7 @@ class SalTcpClientTest(BaseHostTest):
         s.send(data)
         # let remote target terminate the tcp connection
         while True:
-            data = s.recv(1024)
+            data = s.recv(self.RX_SIZE_MAX)
             if not data: 
                 break
         s.close()

--- a/test/host_tests/sal_tcpserver.py
+++ b/test/host_tests/sal_tcpserver.py
@@ -1,0 +1,117 @@
+# Copyright 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+import sys
+import socket
+import select
+import time
+import threading
+from SocketServer import BaseRequestHandler, TCPServer, _eintr_retry
+from mbed_host_tests import BaseHostTest
+
+
+class TCPServerV4(TCPServer):
+    address_family = socket.AF_INET
+    allow_reuse_address = True
+
+    def __init__(self, server_address, RequestHandlerClass):
+        TCPServer.__init__(self, server_address, RequestHandlerClass)
+        self._shutdown_request = False
+
+    def serve_forever(self, poll_interval=0.5):
+        """provide an override that can be shutdown from a request handler.
+        The threading code in the BaseSocketServer class prevented this from working
+        even for a non-threaded blocking server.
+        """
+        try:
+            while not self._shutdown_request:
+                r, w, e = _eintr_retry(select.select, [self], [], [], poll_interval)
+                if self in r:
+                    self._handle_request_noblock()
+        finally:
+            self._shutdown_request = False
+
+class TCPHandler(BaseRequestHandler):
+    MAX_RX_SIZE = 8192
+    def handle(self):
+        """ One handle per connection
+        """
+        print("HOST: Connection received...\n")
+        while True:
+            try:
+                data = self.request.recv(self.MAX_RX_SIZE)
+            except Exception as e:
+                    print("HOST: detected unexpected exception: %s" % str(e))
+                    break
+                
+            if not data: 
+                break
+            
+            print("HOST: Received %s bytes of data\n" % len(data))
+            
+            # try not shutting down the connection and wait for the remote end to close it
+            if data == "shutdown":
+                print("HOST: Requesting server shutdown\n")
+                # give the remote end time to close its connection, which is part of the test
+                time.sleep(5)
+                self.server._shutdown_request = True
+                break
+
+            self.request.sendall(data)
+
+class SalTcpServerTest(BaseHostTest):
+    ERR_SUCCESS = "success"
+    name = 'sal_tcpserver'
+
+    def send_server_ip_port(self, selftest, ip_address, port):
+        """ Set up network host. Reset target and and send server IP via 
+        serial to a mbed board."""
+        # Read 3 lines which are sent from client, This will be fixed in greentea
+        for i in range(0, 3):
+            c = selftest.mbed.serial_readline()
+            if c is None:
+                selftest.print_result(self.RESULT_IO_SERIAL)
+                return
+            selftest.notify("MBED: " + c.strip())
+
+        selftest.notify("HOST: Sending server IP Address to target...")
+        msg = ip_address + ":" + str(port) + "\n"
+        selftest.mbed.serial_write(msg)
+        
+        # mbed greentea framwork support the following for outputing serial console emitted 
+        # from the target, but it doesnt work relibly for me.
+        # selftest.dump_serial()
+        # selftest.dump_serial_end()
+        
+        # until its fixed, the following emits the serial console trace
+        while True:
+            c = selftest.mbed.serial_readline()
+            if c is None:
+                selftest.print_result(self.RESULT_IO_SERIAL)
+                return
+            print "MBED: " + c.strip()
+            
+            # look for the end tag in serial output denoting the test has 
+            # finished, and this can return.
+            if c.strip() == "{{end}}":
+                print "HOST: Terminating Test"
+                break
+        
+    def test(self, selftest):
+        # Returning none will suppress host test from printing success code
+        
+        ret = self.ERR_SUCCESS
+        srv_ipaddr = socket.gethostbyname(socket.gethostname())
+        self.tcpserver = TCPServerV4((srv_ipaddr, 0), TCPHandler)
+        srv_port = self.tcpserver.socket.getsockname()[1]
+        self.tcp_thread = threading.Thread(target=self.tcpserver.serve_forever)
+        self.tcp_thread.start()
+        
+        self.send_server_ip_port(selftest, srv_ipaddr, srv_port)
+        #return ret
+
+    def rampDown(self):
+        self.tcpserver.server_close()
+

--- a/test/host_tests/sal_tcpserver.py
+++ b/test/host_tests/sal_tcpserver.py
@@ -19,19 +19,37 @@ class TCPServerV4(TCPServer):
     def __init__(self, server_address, RequestHandlerClass):
         TCPServer.__init__(self, server_address, RequestHandlerClass)
         self._shutdown_request = False
+        
+        # watchdog guards against the failure mode when the remote target fails 
+        # to send any packets. If the watchdog reaches the high water mark, the 
+        # server is terminated so as not to leave the server thread unterminated
+        self.watchdog = 0.0
 
     def serve_forever(self, poll_interval=0.5):
         """provide an override that can be shutdown from a request handler.
         The threading code in the BaseSocketServer class prevented this from working
         even for a non-threaded blocking server.
         """
+        
         try:
             while not self._shutdown_request:
                 r, w, e = _eintr_retry(select.select, [self], [], [], poll_interval)
                 if self in r:
+                    # reset watchdog
+                    self.watchdog = 0.0
                     self._handle_request_noblock()
+                
+                else:
+                    self.watchdog += poll_interval
+                
+                
+                if self.watchdog > 20.0:
+                    self._shutdown_request = True
+                
         finally:
             self._shutdown_request = False
+        
+        
 
 class TCPHandler(BaseRequestHandler):
     MAX_RX_SIZE = 8192
@@ -60,6 +78,7 @@ class TCPHandler(BaseRequestHandler):
                 break
 
             self.request.sendall(data)
+            
 
 class SalTcpServerTest(BaseHostTest):
     ERR_SUCCESS = "success"
@@ -68,6 +87,9 @@ class SalTcpServerTest(BaseHostTest):
     def send_server_ip_port(self, selftest, ip_address, port):
         """ Set up network host. Reset target and and send server IP via 
         serial to a mbed board."""
+
+        self.watchdog = 0
+
         # Read 3 lines which are sent from client, This will be fixed in greentea
         for i in range(0, 3):
             c = selftest.mbed.serial_readline()
@@ -75,6 +97,7 @@ class SalTcpServerTest(BaseHostTest):
                 selftest.print_result(self.RESULT_IO_SERIAL)
                 return
             selftest.notify("MBED: " + c.strip())
+
 
         selftest.notify("HOST: Sending server IP Address to target...")
         msg = ip_address + ":" + str(port) + "\n"
@@ -91,6 +114,7 @@ class SalTcpServerTest(BaseHostTest):
             if c is None:
                 selftest.print_result(self.RESULT_IO_SERIAL)
                 return
+            
             print "MBED: " + c.strip()
             
             # look for the end tag in serial output denoting the test has 
@@ -98,6 +122,17 @@ class SalTcpServerTest(BaseHostTest):
             if c.strip() == "{{end}}":
                 print "HOST: Terminating Test"
                 break
+
+            # null lines are periodically generated, which can be used to trigger the watchdog
+            elif c.strip() == "":
+                self.watchdog += 1
+                if self.watchdog > 10:
+                    break
+            
+            else:
+                # reset watchdog
+                self.watchdog = 0
+
         
     def test(self, selftest):
         # Returning none will suppress host test from printing success code

--- a/test/host_tests/sal_udpserver.py
+++ b/test/host_tests/sal_udpserver.py
@@ -1,0 +1,150 @@
+"""
+mbed OS
+Copyright (c) 2011-2016 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import socket
+import select
+import threading
+from sys import stdout
+from SocketServer import BaseRequestHandler, UDPServer, _eintr_retry
+from mbed_host_tests import BaseHostTest
+
+SalUdpServerDebug=False
+
+class SalUdpServer(UDPServer):
+    """ UDP Server derived class with a custom serve_forever() implementation 
+    for implementing detection of shutdown command allowing graceful 
+    termination of the host test script"""
+     
+    address_family = socket.AF_INET
+    allow_reuse_address = True
+
+    def __init__(self, server_address, RequestHandlerClass):
+        UDPServer.__init__(self, server_address, RequestHandlerClass)
+        self._shutdown_request = False
+
+    def serve_forever(self, poll_interval=0.5):
+        """Provide an override that can be shutdown from a request handler.
+        The threading code in the BaseSocketServer class prevented this from working
+        even for a non-threaded blocking server.
+        """
+        try:
+            while not self._shutdown_request:
+                r, w, e = _eintr_retry(select.select, [self], [], [], poll_interval)
+                if self in r:
+                    self._handle_request_noblock()
+        finally:
+            self._shutdown_request = False
+
+
+class SalUdpServerEchoCallback(BaseRequestHandler):
+    """UDP Server callback handler for processing rx-ed data. Received data is 
+    echoed back to the sender """
+
+    def handle(self):
+        """ One handle per connection
+        """
+        try:
+            data, socket = self.request
+            print("HOST: Received %d bytes of data" % len(data))
+            
+            if SalUdpServerDebug == True:
+                print "HOST: sending the data back to transmitter at:" 
+                print  self.client_address
+                print "HOST: data:"
+                print data
+                print "HOST: %d bytes sendto() client %s" % (len, str(self.client_address))
+                            
+            if 'shutdown' in data:
+                self.server._shutdown_request = True
+            else:
+                tx_bytes = socket.sendto(data, self.client_address)
+                print("HOST: Sent %d bytes of data" % tx_bytes)
+            
+        except Exception as e:
+            print("HOST: detected unexpected exception: %s" % str(e))
+                
+
+class SalUdpServerTest(BaseHostTest):
+    """
+    mbed greentea framework host test script for udp_echo_client server 
+    side functionality. The test does the following:
+      - creates a UDP Server for echo back to sender any packets received.
+      - communicates the udp server {ipaddr, port} to the DUT via serial
+        so the DUT can send packets to the udp server.
+      - The DUT will send udp packets of various lengths and the UDP server 
+        will echo them back again.
+      - When finished, the DUT will send a shutdown command to the UDP 
+        server causing the udp server thread to terminate, and this 
+        function to return.    
+    """
+    
+    name = 'sal_udpserver'
+
+    def send_server_ip_port(self, selftest, ip_address, port_no):
+        """send the udp server {ipaddr, port} to target via serial console."""
+        
+        # Read 3 lines which are sent from client
+        print "HOST: About to read 3 lines from target before sending UDP Server {ipaddr, port} tuple." 
+        for i in range(0, 3):
+            c = selftest.mbed.serial_readline()
+            if c is None:
+                selftest.print_result(self.RESULT_IO_SERIAL)
+                return
+            print "MBED: " + c.strip()
+
+        print "HOST: Sending server IP Address to target..."
+        connection_str = ip_address + ":" + str(port_no) + "\n"
+        selftest.mbed.serial_write(connection_str)
+
+        # mbed greentea framwork support the following for outputing serial console emitted 
+        # from the target, but it doesnt work relibly for me.
+        # selftest.dump_serial()
+        # selftest.dump_serial_end()
+        
+        # until its fixed, the following emits the serial console trace
+        while True:
+            c = selftest.mbed.serial_readline()
+            if c is None:
+                selftest.print_result(self.RESULT_IO_SERIAL)
+                return
+            print "MBED: " + c.strip()
+            
+            # look for the end tag in serial output denoting the test has 
+            # finished, and this can return.
+            if c.strip() == "{{end}}":
+                print "HOST: Terminating Test"
+                break
+        
+        return selftest.RESULT_SUCCESS 
+
+    def test(self, selftest):
+        """ Method invoked by test framework to implement udp_echo_client 
+        server side functionality."""
+        
+        # socket functions used are selected to promote portability across
+        # windows, linux and mac.
+        srv_ipaddr = socket.gethostbyname(socket.gethostname())
+        self.udpserver = SalUdpServer((srv_ipaddr, 0), SalUdpServerEchoCallback)
+        srv_port = self.udpserver.socket.getsockname()[1]
+
+        print "HOST: Listening for UDP connections on %s:%d." %(srv_ipaddr, srv_port) 
+        udp_thread = threading.Thread(target=self.udpserver.serve_forever)
+        udp_thread.start()
+        
+        self.send_server_ip_port(selftest, srv_ipaddr, srv_port)
+        

--- a/test/init_api/init_api.cpp
+++ b/test/init_api/init_api.cpp
@@ -25,7 +25,7 @@ void app_start(int argc, char *argv[])
 {
     (void) argc;
     (void) argv;
-    MBED_HOSTTEST_TIMEOUT(5);
+    MBED_HOSTTEST_TIMEOUT(60);
     MBED_HOSTTEST_SELECT(default);
     MBED_HOSTTEST_DESCRIPTION(Socket Abstraction Layer construction and utility test);
     MBED_HOSTTEST_START("SAL_INIT_UTIL");

--- a/test/init_api/init_api.cpp
+++ b/test/init_api/init_api.cpp
@@ -1,4 +1,6 @@
-/*
+/**
+ * @file init_api.cpp
+ *
  * PackageLicenseDeclared: Apache-2.0
  * Copyright (c) 2015 ARM Limited
  *
@@ -21,21 +23,66 @@
 #include "EthernetInterface.h"
 #include "mbed-drivers/test_env.h"
 
-void app_start(int argc, char *argv[])
+/* The mbed greentea host test watchdog timeout value is set such that
+ * the test case is expected to report the test {{end}} terminator
+ * before the timeout value expires. If this is not the case, greentea
+ * will terminate the test case and perform recovery actions.
+ */
+#ifndef INIT_API_MBED_HOSTTEST_TIMEOUT
+#define INIT_API_MBED_HOSTTEST_TIMEOUT 60
+#endif
+
+/** @brief Main application entry point for the test case
+ *
+ *  This mbed greentea test case implements a test case for socket creation
+ *  and the conversion of a dotted decimal string to a struct socket_addr.
+ *  @return void
+ */
+void app_start(int, char**)
 {
-    (void) argc;
-    (void) argv;
-    MBED_HOSTTEST_TIMEOUT(60);
+    int i = 0;
+    int tests_pass = 1;
+    int rc;
+    /* DHCP lookup can take several seconds e.g. 10s (in some cases much longer)
+     * Taking 10s as a reasonable figure
+     *   5 * 10s = 50s,
+     * 50s is shorter than INIT_API_MBED_HOSTTEST_TIMEOUT
+     */
+    const int max_dhcp_retries = 5;
+    EthernetInterface eth;
+
+    /* mbed greentea init */
+    MBED_HOSTTEST_TIMEOUT(INIT_API_MBED_HOSTTEST_TIMEOUT);
     MBED_HOSTTEST_SELECT(default);
     MBED_HOSTTEST_DESCRIPTION(Socket Abstraction Layer construction and utility test);
     MBED_HOSTTEST_START("SAL_INIT_UTIL");
 
-    int tests_pass = 1;
-    int rc;
-    EthernetInterface eth;
     /* Initialise with DHCP, connect, and start up the stack */
     eth.init();
-    eth.connect();
+
+    /* if the interface fails to get a dhcp lease then retry */
+    for(i = 0; i < max_dhcp_retries; i++)
+    {
+       rc = eth.connect();
+        /* break if we get a lease */
+       if(rc == 0)
+       {
+           printf("TCP client IP Address is %s\r\n", eth.getIPAddress());
+           break;
+       }
+       else
+       {
+           printf("DHCP failure number %d. Retrying DHCP.\r\n", i);
+       }
+
+    }
+    if(i == max_dhcp_retries)
+    {
+        printf("Maximum number of DHCP retries (%d) exceeded. Terminating test.\r\n", i);
+        tests_pass = 0;
+        notify_completion(tests_pass);
+        return;
+    }
 
     do {
         socket_error_t err = lwipv4_socket_init();

--- a/test/tcp_echo_client/tcp_echo_client.cpp
+++ b/test/tcp_echo_client/tcp_echo_client.cpp
@@ -20,15 +20,197 @@
 #include "sal-stack-lwip/lwipv4_init.h"
 #include "EthernetInterface.h"
 #include "mbed-drivers/test_env.h"
+#include "sal/socket_api.h"
 
-void app_start(int argc, char *argv[])
+#ifndef TCP_EC_SOCKET_TEST_TIMEOUT
+#define TCP_EC_SOCKET_TEST_TIMEOUT 1.0f
+#endif
+
+
+static struct socket *tcp_ec_client_socket_g;
+static volatile bool tcp_ec_client_event_done_g;
+static volatile bool tcp_ec_client_rx_done_g;
+static volatile bool tcp_ec_client_tx_done_g;
+static volatile struct socket_tx_info tcp_ec_client_tx_info_g;
+static volatile struct socket_event tcp_ec_client_event_g;
+static volatile int tcp_ec_closed;
+static volatile int tcp_ec_connected;
+
+volatile int tcp_ec_timeout_g;
+static void onTimeout() {
+    tcp_ec_timeout_g = 1;
+}
+
+
+/*****************************************************************************
+ * FUNCTION: tcp_ec_sock_addr_port_dump
+ *  pretty print a socket address and port with description
+ * ARGUMENTS:
+ *  description     client string to provide contextural information for
+ *                  the ipaddr:port tuple
+ *  addr            ip address data structure
+ *  port            port number
+ * RETURN:
+ *  None
+ *****************************************************************************/
+static inline void tcp_ec_sock_addr_port_dump(const char* description, struct socket_addr* saddr, uint16_t port)
 {
-    (void) argc;
-    (void) argv;
+    if(saddr)
+    {
+        TEST_PRINT("%s:%s:%d\r\n", description, inet_ntoa(*saddr), port);
+    }
+}
+
+/*****************************************************************************
+ * FUNCTION: tcp_ec_client_cb
+ * callback function for handling tx/rx/etc event indications.
+ * script
+ * ARGUMENTS:
+ *  None
+ * RETURN:
+ *  None
+ *****************************************************************************/
+static void tcp_ec_client_cb()
+{
+    struct socket_event *e = tcp_ec_client_socket_g->event;
+    event_flag_t event = e->event;
+    switch (event) {
+        case SOCKET_EVENT_RX_DONE:
+            tcp_ec_client_rx_done_g = true;
+            break;
+        case SOCKET_EVENT_TX_DONE:
+            tcp_ec_client_tx_done_g = true;
+            tcp_ec_client_tx_info_g.sentbytes = e->i.t.sentbytes;
+            break;
+        case SOCKET_EVENT_DISCONNECT:
+            tcp_ec_closed = 1;
+            break;
+        case SOCKET_EVENT_CONNECT:
+            tcp_ec_connected = 1;
+            break;
+        default:
+            memcpy((void *) &tcp_ec_client_event_g, (const void*)e, sizeof(e));
+            tcp_ec_client_event_done_g = true;
+            break;
+    }
+}
+
+/*****************************************************************************
+ * FUNCTION: tcp_ec_send_shutdown_host_script
+ * send a shutdown command to the host test script to terminate host pc test
+ * script
+ * ARGUMENTS:
+ * srv_addr_s   dotted decimal ip addr string of the remote tcp echo server
+ * srv_port     port number of the remote tcp echo relay server
+ * RETURN:
+ *  0 => success, !=0 => failure.
+ *****************************************************************************/
+static int tcp_ec_send_shutdown_host_script(const char* srv_addr_s, uint16_t srv_port)
+{
+    struct socket s;
+    socket_error_t err;
+    struct socket_addr srv_saddr = {0, 0, 0, 0};
+    struct socket_addr local_saddr = {0, 0, 0, 0};
+    const struct socket_api *api = socket_get_api(SOCKET_STACK_LWIP_IPV4);
+    mbed::Timeout to;
+    const char* shutdown_cmd = "shutdown";
+    uint16_t local_port = 0;
+
+    TEST_CLEAR();
+    tcp_ec_client_socket_g = &s;
+
+    /* Create the socket */
+    err = api->init();
+    if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+        TEST_RETURN();
+    }
+    s.impl = NULL;
+    err = api->create(&s, SOCKET_AF_INET4, SOCKET_STREAM, &tcp_ec_client_cb);
+    if (!TEST_EQ(err, SOCKET_ERROR_NONE))
+    {
+        TEST_EXIT();
+    }
+    err = api->bind(&s, &local_saddr, local_port);
+    if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+        TEST_RETURN();
+    }
+
+    err = api->str2addr(&s, &srv_saddr, srv_addr_s);
+    TEST_EQ(err, SOCKET_ERROR_NONE);
+    tcp_ec_sock_addr_port_dump("server", &srv_saddr, srv_port);
+
+
+    tcp_ec_timeout_g = 0;
+    tcp_ec_connected = 0;
+    to.attach(onTimeout, TCP_EC_SOCKET_TEST_TIMEOUT);
+    err = api->connect(&s, &srv_saddr, srv_port);
+    TEST_EQ(err, SOCKET_ERROR_NONE);
+    if (err!=SOCKET_ERROR_NONE) {
+        printf("err = %d\r\n", err);
+    }
+    while (!tcp_ec_connected && !tcp_ec_timeout_g)
+    {
+        __WFI();
+    }
+    to.detach();
+    TEST_EQ(tcp_ec_timeout_g, 0);
+
+    tcp_ec_client_tx_done_g = false;
+    tcp_ec_client_rx_done_g = false;
+    tcp_ec_timeout_g = 0;
+    to.attach(onTimeout, TCP_EC_SOCKET_TEST_TIMEOUT);
+    err = api->send(&s, shutdown_cmd, strlen(shutdown_cmd));
+    if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+        TEST_PRINT("Failed to send shutdown command %u bytes. err=%s\r\n", strlen(shutdown_cmd), socket_strerror(err));
+    }
+    else
+    {
+        size_t tx_bytes = 0;
+        do {
+            /* Wait for the onSent callback */
+            while (!tcp_ec_timeout_g && !tcp_ec_client_tx_done_g) {
+                __WFI();
+            }
+            if (!TEST_EQ(tcp_ec_timeout_g,0)) {
+                break;
+            }
+            if (!TEST_NEQ(tcp_ec_client_tx_info_g.sentbytes, 0)) {
+                break;
+            }
+            tx_bytes += tcp_ec_client_tx_info_g.sentbytes;
+            if (tx_bytes < strlen(shutdown_cmd)) {
+                tcp_ec_client_tx_done_g = false;
+                continue;
+            }
+            to.detach();
+            TEST_EQ(tx_bytes, strlen(shutdown_cmd));
+            break;
+        } while (1);
+    }
+
+    /* this test depends on us closing the socket before the remote peer does
+     * if the remote server were to close first then the closing a closed connection
+     * would return an error. For this reason the sal_tcpserver waits 5s before terminating
+     * the server */
+    err = api->close(&s);
+    TEST_EQ(err, SOCKET_ERROR_NONE);
+
+    /* destroy the socket */
+    err = api->destroy(&s);
+    TEST_EQ(err, SOCKET_ERROR_NONE);
+
+test_exit:
+    TEST_RETURN();
+    return 0;
+}
+
+
+void app_start(int , char **)
+{
     MBED_HOSTTEST_TIMEOUT(20);
-    MBED_HOSTTEST_SELECT(tcpecho_client_ext_auto);
-    MBED_HOSTTEST_DESCRIPTION(Socket Abstraction Layer TCP Echo Client test);
-    MBED_HOSTTEST_START("SAL_TCP_ECHO_CLIENT");
+    MBED_HOSTTEST_SELECT(sal_tcpserver);
+    MBED_HOSTTEST_DESCRIPTION(SalTcpServerTest);
+    MBED_HOSTTEST_START("Socket Abstract Layer TCP Connection/Tx/Rx Socket Stream Test");
 
     int tests_pass = 1;
     int rc;
@@ -43,7 +225,7 @@ void app_start(int argc, char *argv[])
     } ip_addr = {0, 0, 0, 0};
     int port = 0;
 
-    printf("MBED: TCPCllient waiting for server IP and port...\r\n");
+    printf("MBED: SAL TCP Client waiting for server IP and port...\r\n");
     scanf("%d.%d.%d.%d:%d", &ip_addr.ip_1, &ip_addr.ip_2, &ip_addr.ip_3, &ip_addr.ip_4, &port);
     printf("MBED: Address received: %d.%d.%d.%d:%d\r\n", ip_addr.ip_1, ip_addr.ip_2, ip_addr.ip_3, ip_addr.ip_4, port);
 
@@ -67,6 +249,10 @@ void app_start(int argc, char *argv[])
 
         rc = socket_api_test_echo_client_connected(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, SOCKET_STREAM, true, ipbuffer, port);
         tests_pass = tests_pass && rc;
+
+        rc = tcp_ec_send_shutdown_host_script(ipbuffer, port);
+        tests_pass = tests_pass && rc;
+
     } while (0);
     notify_completion(tests_pass);
 }

--- a/test/tcp_echo_client/tcp_echo_client.cpp
+++ b/test/tcp_echo_client/tcp_echo_client.cpp
@@ -207,7 +207,7 @@ test_exit:
 
 void app_start(int , char **)
 {
-    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_TIMEOUT(60);
     MBED_HOSTTEST_SELECT(sal_tcpserver);
     MBED_HOSTTEST_DESCRIPTION(SalTcpServerTest);
     MBED_HOSTTEST_START("Socket Abstract Layer TCP Connection/Tx/Rx Socket Stream Test");

--- a/test/tcp_echo_server/tcp_echo_server.cpp
+++ b/test/tcp_echo_server/tcp_echo_server.cpp
@@ -1,4 +1,6 @@
-/*
+/**
+ * @file tcp_echo_server.cpp
+ *
  * PackageLicenseDeclared: Apache-2.0
  * Copyright (c) 2015 ARM Limited
  *
@@ -21,25 +23,72 @@
 #include "EthernetInterface.h"
 #include "mbed-drivers/test_env.h"
 
+/*
+ * Defines
+ */
+
+/* The mbed greentea host test watchdog timeout value is set such that
+ * the test case is expected to report the test {{end}} terminator
+ * before the timeout value expires. If this is not the case, greentea
+ * will terminate the test case and perform recovery actions.
+ */
+#ifndef TCP_ECHO_SERVER_MBED_HOSTTEST_TIMEOUT
+#define TCP_ECHO_SERVER_MBED_HOSTTEST_TIMEOUT 60
+#endif
+
 #define TEST_PORT2 32765
 
-void app_start(int argc, char *argv[])
+/** @brief Main application entry point for the test case
+ *
+ *  This mbed greentea test case implements a tcp server which echos received
+ *  data back to the transmitter (sal_tcpclient.py).
+ *  @return void
+ */
+void app_start(int , char**)
 {
-    (void) argc;
-    (void) argv;
+    int i = 0;
     int tests_pass = 1;
     int rc;
+    /* DHCP lookup can take several seconds e.g. 10s (in some cases much longer)
+     * Taking 10s as a reasonable figure
+     *   5 * 10s = 50s,
+     * 50s is shorter than TCP_ECHO_SERVER_MBED_HOSTTEST_TIMEOUT
+     */
+    const int max_dhcp_retries = 5;
     EthernetInterface eth;
 
     /* mbed greentea init */
-    MBED_HOSTTEST_TIMEOUT(60);
+    MBED_HOSTTEST_TIMEOUT(TCP_ECHO_SERVER_MBED_HOSTTEST_TIMEOUT);
     MBED_HOSTTEST_SELECT(sal_tcpclient);
     MBED_HOSTTEST_DESCRIPTION(SalTcpClientTest);
     MBED_HOSTTEST_START("Socket Abstract Layer TCP Server Connection/Tx/Rx Socket Stream Test");
 
     /* Initialise with DHCP, connect, and start up the stack */
     eth.init();
-    eth.connect();
+
+    /* if the interface fails to get a dhcp lease then retry */
+    for(i = 0; i < max_dhcp_retries; i++)
+    {
+       rc = eth.connect();
+        /* break if we get a lease */
+       if(rc == 0)
+       {
+           printf("TCP client IP Address is %s\r\n", eth.getIPAddress());
+           break;
+       }
+       else
+       {
+           printf("DHCP failure number %d. Retrying DHCP.\r\n", i);
+       }
+
+    }
+    if(i == max_dhcp_retries)
+    {
+        printf("Maximum number of DHCP retries (%d) exceeded. Terminating test.\r\n", i);
+        tests_pass = 0;
+        notify_completion(tests_pass);
+        return;
+    }
     notify_start();
 
     do {

--- a/test/tcp_echo_server/tcp_echo_server.cpp
+++ b/test/tcp_echo_server/tcp_echo_server.cpp
@@ -21,9 +21,6 @@
 #include "EthernetInterface.h"
 #include "mbed-drivers/test_env.h"
 
-#define TEST_SERVER "192.168.2.1"
-#define TEST_PORT0 32767
-#define TEST_PORT1 32766
 #define TEST_PORT2 32765
 
 void app_start(int argc, char *argv[])
@@ -35,7 +32,7 @@ void app_start(int argc, char *argv[])
     EthernetInterface eth;
 
     /* mbed greentea init */
-    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_TIMEOUT(60);
     MBED_HOSTTEST_SELECT(sal_tcpclient);
     MBED_HOSTTEST_DESCRIPTION(SalTcpClientTest);
     MBED_HOSTTEST_START("Socket Abstract Layer TCP Server Connection/Tx/Rx Socket Stream Test");

--- a/test/tcp_echo_server/tcp_echo_server.cpp
+++ b/test/tcp_echo_server/tcp_echo_server.cpp
@@ -34,6 +34,12 @@ void app_start(int argc, char *argv[])
     int rc;
     EthernetInterface eth;
 
+    /* mbed greentea init */
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(sal_tcpclient);
+    MBED_HOSTTEST_DESCRIPTION(SalTcpClientTest);
+    MBED_HOSTTEST_START("Socket Abstract Layer TCP Server Connection/Tx/Rx Socket Stream Test");
+
     /* Initialise with DHCP, connect, and start up the stack */
     eth.init();
     eth.connect();

--- a/test/tcp_echo_server/tcp_echo_server.cpp
+++ b/test/tcp_echo_server/tcp_echo_server.cpp
@@ -33,6 +33,7 @@ void app_start(int argc, char *argv[])
     int tests_pass = 1;
     int rc;
     EthernetInterface eth;
+
     /* Initialise with DHCP, connect, and start up the stack */
     eth.init();
     eth.connect();
@@ -52,18 +53,6 @@ void app_start(int argc, char *argv[])
         // Need create/destroy for all subsequent tests
         // str2addr is required for connect test
         if (!tests_pass) break;
-
-        rc = socket_api_test_connect_close(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET6,TEST_SERVER, TEST_PORT0);
-        tests_pass = tests_pass && rc;
-
-        rc = socket_api_test_echo_client_connected(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, SOCKET_STREAM, true, TEST_SERVER, TEST_PORT0);
-        tests_pass = tests_pass && rc;
-
-        rc = socket_api_test_echo_client_connected(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, SOCKET_DGRAM, true, TEST_SERVER, TEST_PORT1);
-        tests_pass = tests_pass && rc;
-
-        rc = socket_api_test_echo_client_connected(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, SOCKET_DGRAM, false, TEST_SERVER, TEST_PORT1);
-        tests_pass = tests_pass && rc;
 
         rc = socket_api_test_echo_server_stream(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, eth.getIPAddress(), TEST_PORT2);
         tests_pass = tests_pass && rc;

--- a/test/udp_echo_client/udp_echo_client.cpp
+++ b/test/udp_echo_client/udp_echo_client.cpp
@@ -17,23 +17,462 @@
 
 #include "sal/test/ctest_env.h"
 #include "sal/test/sal_test_api.h"
+#include "sal/test/ctest_env.h"
 #include "sal-stack-lwip/lwipv4_init.h"
+#include "sal/socket_api.h"
 #include "EthernetInterface.h"
 #include "mbed-drivers/test_env.h"
+#include "mbed-drivers/Timeout.h"
+#include "mbed-drivers/Ticker.h"
+#include "mbed-drivers/mbed.h"
 
-#define TEST_SERVER "192.168.2.1"
-#define TEST_PORT0 32767
-#define TEST_PORT1 32766
-#define TEST_PORT2 32765
 
-void app_start(int argc, char *argv[])
+#ifndef SOCKET_TEST_TIMEOUT
+#define SOCKET_TEST_TIMEOUT 1.0f
+#endif
+
+#ifndef SOCKET_SENDBUF_BLOCKSIZE
+#define SOCKET_SENDBUF_BLOCKSIZE 32
+#endif
+
+#ifndef SOCKET_SENDBUF_MAXSIZE
+#define SOCKET_SENDBUF_MAXSIZE 4096
+#endif
+
+#ifndef SOCKET_SENDBUF_ITERATIONS
+#define SOCKET_SENDBUF_ITERATIONS 8
+#endif
+
+static struct socket *udp_ec_client_socket_g;
+static volatile bool udp_ec_client_event_done_g;
+static volatile bool udp_ec_client_rx_done_g;
+static volatile bool udp_ec_client_tx_done_g;
+static volatile struct socket_tx_info udp_ec_client_tx_info_g;
+static volatile struct socket_event udp_ec_client_event_g;
+
+volatile int udp_ec_timeout_g;
+static void onTimeout() {
+    udp_ec_timeout_g = 1;
+}
+
+typedef struct udp_ec_tx_rx_context_t
 {
-    (void) argc;
-    (void) argv;
+    EthernetInterface* eth_if;
+} udp_ec_tx_rx_context_t;
 
-    int tests_pass = 1;
+/*****************************************************************************
+ * FUNCTION: udp_ec_sock_addr_port_dump
+ *  pretty print a socket address and port with description
+ * ARGUMENTS:
+ *  description		client string to provide contextural information for
+ *                  the ipaddr:port tuple
+ *  addr			ip address data structure
+ *  port			port number
+ * RETURN:
+ *  None
+ *****************************************************************************/
+static inline void udp_ec_sock_addr_port_dump(const char* description, struct socket_addr* saddr, uint16_t port)
+{
+	if(saddr)
+	{
+        TEST_PRINT("%s:%s:%d\r\n", description, inet_ntoa(*saddr), port);
+	}
+}
+
+/*****************************************************************************
+ * FUNCTION: udp_ec_client_cb
+ * callback function for handling tx/rx/etc event indications.
+ * script
+ * ARGUMENTS:
+ *  None
+ * RETURN:
+ *  None
+ *****************************************************************************/
+static void udp_ec_client_cb()
+{
+    struct socket_event *e = udp_ec_client_socket_g->event;
+    event_flag_t event = e->event;
+    switch (event) {
+        case SOCKET_EVENT_RX_DONE:
+            udp_ec_client_rx_done_g = true;
+            break;
+        case SOCKET_EVENT_TX_DONE:
+            udp_ec_client_tx_done_g = true;
+            udp_ec_client_tx_info_g.sentbytes = e->i.t.sentbytes;
+            break;
+        default:
+            memcpy((void *) &udp_ec_client_event_g, (const void*)e, sizeof(e));
+            udp_ec_client_event_done_g = true;
+            break;
+    }
+}
+
+/*****************************************************************************
+ * FUNCTION: udp_ec_send_shutdown_host_script
+ * send a shutdown command to the host test script to terminate host pc test
+ * script
+ * ARGUMENTS:
+ * srv_addr_s   dotted decimal ip addr string of the remote udp echo server
+ * srv_port     port number of the remote udp echo relay server
+ * RETURN:
+ *  0 => success, !=0 => failure.
+ *****************************************************************************/
+static int udp_ec_send_shutdown_host_script(const char* srv_addr_s, uint16_t srv_port)
+{
+    struct socket s;
+    socket_error_t err;
+    struct socket_addr srv_saddr = {0, 0, 0, 0};
+    struct socket_addr local_saddr = {0, 0, 0, 0};
+    const struct socket_api *api = socket_get_api(SOCKET_STACK_LWIP_IPV4);
+    mbed::Timeout to;
+    const char* shutdown_cmd = "shutdown";
+    uint16_t local_port = 0;
+
+    TEST_CLEAR();
+    udp_ec_client_socket_g = &s;
+
+    /* Create the socket */
+    err = api->init();
+    if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+        TEST_RETURN();
+    }
+    s.impl = NULL;
+    err = api->create(&s, SOCKET_AF_INET4, SOCKET_DGRAM, &udp_ec_client_cb);
+    if (!TEST_EQ(err, SOCKET_ERROR_NONE))
+    {
+        TEST_EXIT();
+    }
+	err = api->bind(&s, &local_saddr, local_port);
+	if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+		TEST_RETURN();
+	}
+
+    err = api->str2addr(&s, &srv_saddr, srv_addr_s);
+    TEST_EQ(err, SOCKET_ERROR_NONE);
+	udp_ec_sock_addr_port_dump("server", &srv_saddr, srv_port);
+
+    udp_ec_client_tx_done_g = false;
+    udp_ec_client_rx_done_g = false;
+    udp_ec_timeout_g = 0;
+    to.attach(onTimeout, SOCKET_TEST_TIMEOUT);
+	err = api->send_to(&s, shutdown_cmd, strlen(shutdown_cmd), &srv_saddr, srv_port);
+	if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+        TEST_PRINT("Failed to send shutdown command %u bytes. err=%s\r\n", strlen(shutdown_cmd), socket_strerror(err));
+    }
+	else
+    {
+        size_t tx_bytes = 0;
+        do {
+            /* Wait for the onSent callback */
+            while (!udp_ec_timeout_g && !udp_ec_client_tx_done_g) {
+                __WFI();
+            }
+            if (!TEST_EQ(udp_ec_timeout_g,0)) {
+                break;
+            }
+            if (!TEST_NEQ(udp_ec_client_tx_info_g.sentbytes, 0)) {
+                break;
+            }
+            tx_bytes += udp_ec_client_tx_info_g.sentbytes;
+            if (tx_bytes < strlen(shutdown_cmd)) {
+                udp_ec_client_tx_done_g = false;
+                continue;
+            }
+            to.detach();
+            TEST_EQ(tx_bytes, strlen(shutdown_cmd));
+            break;
+        } while (1);
+    }
+
+	/* this test depends on us closing the socket before the remote peer does */
+	err = api->close(&s);
+	TEST_EQ(err, SOCKET_ERROR_NONE);
+
+    /* destroy the socket */
+    err = api->destroy(&s);
+    TEST_EQ(err, SOCKET_ERROR_NONE);
+
+test_exit:
+    return 0;
+}
+
+/*****************************************************************************
+ * FUNCTION: udp_ec_tx_rx_from_test
+ * This function implements a udp transmitter/receiver to send udp packets to
+ * a udp echo relay, and then received them back again. The rx packet data is
+ * compared with that transmitted to verify its the same.
+ *
+ * ARGUMENTS:
+ * srv_ipaddr_s	dotted decimal ip addr string of the remote udp echo server
+ * srv_port     port number of the remote udp echo relay server
+ * connect      connect == false => sendto(), recv_from() will be used.
+ *              connect == true => connect(), send(), recv() will be used.
+ * context      context data needed to check if tests have passed.
+ * RETURN:
+ *  0 => success, !=0 => failure.
+ *****************************************************************************/
+static int udp_ec_tx_rx_from_test(const char* srv_ipaddr_s, uint16_t srv_port, bool connect, udp_ec_tx_rx_context_t* context)
+{
+    int ret = 0;
+    uint16_t local_port = 0;
+    uint16_t rxport = 0;
+    struct socket s;
+    struct socket_addr srv_saddr = {0, 0, 0, 0};
+    struct socket_addr rx_saddr = {0, 0, 0, 0};
+    struct socket_addr local_saddr = {0, 0, 0, 0};
+    struct socket_addr test_saddr = {0, 0, 0, 0};
+    socket_error_t err;
+    const struct socket_api *api = socket_get_api(SOCKET_STACK_LWIP_IPV4);
+    mbed::Timeout to;
+
+    TEST_PRINT("server: %s:%d\r\n", srv_ipaddr_s, (int) srv_port);
+    udp_ec_client_socket_g = &s;
+    TEST_CLEAR();
+    if (!TEST_NEQ(api, NULL))
+    {
+        /* Test cannot continue without API. */
+        TEST_RETURN();
+    }
+    err = api->init();
+    if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+        TEST_RETURN();
+    }
+
+    void *data = malloc(SOCKET_SENDBUF_MAXSIZE);
+    /* Zero the socket implementation, reason unknown */
+    s.impl = NULL;
+    err = api->create(&s, SOCKET_AF_INET4, SOCKET_DGRAM, &udp_ec_client_cb);
+    if (!TEST_EQ(err, SOCKET_ERROR_NONE))
+    {
+        TEST_EXIT();
+    }
+
+    err = api->str2addr(&s, &srv_saddr, srv_ipaddr_s);
+    TEST_EQ(err, SOCKET_ERROR_NONE);
+	udp_ec_sock_addr_port_dump("remote udp server", &srv_saddr, srv_port);
+
+	err = api->bind(&s, &local_saddr, local_port);
+	if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+	    TEST_PRINT("bind() failed to local ipaddr:port\r\n");
+		TEST_RETURN();
+	}
+
+	udp_ec_client_event_g.event = SOCKET_EVENT_CONNECT;
+	udp_ec_client_event_done_g = true;
+
+	/* check the binding of the local interface*/
+	api->get_local_addr(&s, &local_saddr);
+	api->get_local_port(&s, &local_port);
+    udp_ec_sock_addr_port_dump("udp local after bind()", &local_saddr, local_port);
+
+    if(connect)
+    {
+        err = api->connect(&s, &srv_saddr, srv_port);
+        if (!TEST_EQ(err, SOCKET_ERROR_NONE))
+        {
+            TEST_EXIT();
+        }
+        api->get_local_addr(&s, &local_saddr);
+        api->get_local_port(&s, &local_port);
+        udp_ec_sock_addr_port_dump("udp local after connect()", &local_saddr, local_port);
+
+        /* check that the local_saddr is not 0.0.0.0 */
+        ret = socket_addr_is_any(&local_saddr);
+        if(!TEST_EQ(ret, 0)) {
+            TEST_PRINT("[FAIL] connect() failed as connected local address (%s) is INADDR_ANY\r\n", inet_ntoa(local_saddr));
+        }
+
+        /* check that the local_saddr is is the correct i/f to get to srv_saddr
+         * this implementation assumes there is only 1 ethernet interface */
+        inet_aton(context->eth_if->getIPAddress(), &test_saddr);
+        ret = socket_addr_cmp(&local_saddr, &test_saddr);
+        if(!TEST_EQ(ret, 0)) {
+            TEST_PRINT("[FAIL] connect() failed as connected local address (%s) doesnt match ethernet i/f ip address(%s)\r\n", inet_ntoa(local_saddr), context->eth_if->getIPAddress());
+        }
+    }
+
+    /* Loop for several iteration sending progressively larger packets */
+    for (size_t i = 0; i < SOCKET_SENDBUF_ITERATIONS; i++)
+    {
+        /* Fill some data into a buffer */
+        const size_t nWords = SOCKET_SENDBUF_BLOCKSIZE * (1 << i) / sizeof(uint16_t);
+        for (size_t j = 0; j < nWords; j++) {
+            *((uint16_t*) data + j) = j;
+        }
+        /* Send the data */
+        udp_ec_client_tx_done_g = false;
+        udp_ec_client_rx_done_g = false;
+        udp_ec_timeout_g = 0;
+        to.attach(onTimeout, SOCKET_TEST_TIMEOUT);
+        if(connect)
+        {
+            err = api->send(&s, data, nWords * sizeof(uint16_t));
+        }
+        else
+        {
+            err = api->send_to(&s, data, nWords * sizeof(uint16_t), &srv_saddr, srv_port);
+        }
+
+		if (!TEST_EQ(err, SOCKET_ERROR_NONE))
+		{
+            TEST_PRINT("Failed to send %u bytes. err=%s\r\n", nWords * sizeof(uint16_t), socket_strerror(err));
+        }
+		else
+        {
+            size_t tx_bytes = 0;
+            do {
+                /* Wait for the onSent callback */
+                while (!udp_ec_timeout_g && !udp_ec_client_tx_done_g) {
+                    __WFI();
+                }
+                if (!TEST_EQ(udp_ec_timeout_g,0)) {
+                    break;
+                }
+                if (!TEST_NEQ(udp_ec_client_tx_info_g.sentbytes, 0)) {
+                    break;
+                }
+                tx_bytes += udp_ec_client_tx_info_g.sentbytes;
+                if (tx_bytes < nWords * sizeof(uint16_t)) {
+                    udp_ec_client_tx_done_g = false;
+                    continue;
+                }
+                to.detach();
+                if(TEST_EQ(tx_bytes, nWords * sizeof(uint16_t)))
+                {
+                    TEST_PRINT("TARGET sent %d bytes\r\n", tx_bytes);
+                }
+                else
+                {
+                    TEST_PRINT("ERROR: TARGET did not send successfully\r\n");
+                }
+
+                break;
+            } while (1);
+        }
+        udp_ec_timeout_g = 0;
+        to.attach(onTimeout, SOCKET_TEST_TIMEOUT);
+        memset(data, 0, nWords * sizeof(uint16_t));
+
+        /* Wait for the onReadable callback */
+        size_t rx_bytes = 0;
+        do
+        {
+        	while (!udp_ec_timeout_g && !udp_ec_client_rx_done_g) {
+                __WFI();
+            }
+            if (!TEST_EQ(udp_ec_timeout_g,0)) {
+                break;
+            }
+            size_t len = SOCKET_SENDBUF_MAXSIZE - rx_bytes;
+
+			memcpy(&rx_saddr, &srv_saddr, sizeof(rx_saddr));
+            if(connect)
+            {
+                err = api->recv(&s, (void*) ((uintptr_t) data + rx_bytes), &len);
+            }
+            else
+            {
+            	err = api->recv_from(&s, (void*) ((uintptr_t) data + rx_bytes), &len, &rx_saddr, &rxport);
+            }
+
+            if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+                TEST_PRINT("[FAIL] failed to receive packet data\r\n");
+                break;
+            }
+			/* BUG: note returned port is correct for the first packet of a udp receive
+			 * but if its fragmented then the 2nd call to receive returns an incorrect ipaddr and port.
+			 */
+			int rc = memcmp(&rx_saddr.ipv6be, &srv_saddr.ipv6be, sizeof(rx_saddr.ipv6be));
+			if(!TEST_EQ(rc, 0)) {
+	            udp_ec_sock_addr_port_dump("[FAIL] transmitter address", &rx_saddr, rxport);
+				TEST_PRINT("[FAIL] Possibly packet fragment received, or spurious packet\r\n");
+			}
+			if(!TEST_EQ(rxport, srv_port))
+			{
+                udp_ec_sock_addr_port_dump("[FAIL] transmitter port error:server_ipaddr:srv_port", &srv_saddr, srv_port);
+                udp_ec_sock_addr_port_dump("[FAIL] transmitter port error:rx_saddr:rxport", &rx_saddr, rxport);
+			}
+            rx_bytes += len;
+            if (rx_bytes < nWords * sizeof(uint16_t)) {
+                /* continue to try to receive the rest of the data*/
+                continue;
+            }
+            else if(rx_bytes== nWords * sizeof(uint16_t))
+            {
+                TEST_PRINT("TARGET received %d bytes\r\n", rx_bytes);
+                udp_ec_client_rx_done_g = true;
+                break;
+            }
+        } while (1);
+        to.detach();
+
+        if(!TEST_EQ(rx_bytes, nWords * sizeof(uint16_t))) {
+            TEST_PRINT("[FAIL] Expected %u, got %u\r\n", nWords * sizeof(uint16_t), rx_bytes);
+        }
+
+        /* Validate that the two buffers are the same */
+        bool match = true;
+        size_t j;
+        for (j = 0; match && j < nWords; j++) {
+            match = (*((uint16_t*) data + j) == j);
+        }
+        if(!TEST_EQ(match, true)) {
+            TEST_PRINT("Mismatch in %u byte packet at offset %u\r\n", nWords * sizeof(uint16_t), j * sizeof(uint16_t));
+        }
+    }
+
+	udp_ec_client_event_done_g = false;
+	err = api->close(&s);
+	TEST_EQ(err, SOCKET_ERROR_NONE);
+
+    err = api->destroy(&s);
+    TEST_EQ(err, SOCKET_ERROR_NONE);
+
+test_exit:
+    free(data);
+    TEST_RETURN();
+}
+
+/*****************************************************************************
+ * FUNCTION: app_start
+ *  main() for udp_echo_client test, which tests the socket abtract layer
+ *  udp socket interface by doing the following:
+ *  - calling init(), create(), bind(), sendto(), recv_from(), close(),
+ *    destroy(), and sending/receiving various size packets including len>mtu.
+ *  - calling init(), create(), bind(), connect(), send(), recv(), close(),
+ *    destroy(), and sending/receiving various size packets including len>mtu.
+ * ARGUMENTS:
+ *  None
+ * RETURN:
+ *  None
+ *****************************************************************************/
+void app_start(int, char**)
+{
+    char udp_srv_ipaddr_s[16];
     int rc;
+    int port = 0;
+    int tests_pass = 1;
     EthernetInterface eth;
+    udp_ec_tx_rx_context_t context = {&eth};
+
+    struct s_ip_address
+    {
+        int ip_1;
+        int ip_2;
+        int ip_3;
+        int ip_4;
+    } ip_addr = {0, 0, 0, 0};
+
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(sal_udpserver);
+    MBED_HOSTTEST_DESCRIPTION(SalUdpServerTest);
+    MBED_HOSTTEST_START("Socket Abstract Layer UDP Connection/Tx/Rx Socket Stream Test");
+
+    printf("MBED: SAL UDP Client waiting for server IP and port\r\n");
+    scanf("%d.%d.%d.%d:%d", &ip_addr.ip_1, &ip_addr.ip_2, &ip_addr.ip_3, &ip_addr.ip_4, &port);
+    printf("MBED: Address received: %d.%d.%d.%d:%d\r\n", ip_addr.ip_1, ip_addr.ip_2, ip_addr.ip_3, ip_addr.ip_4, port);
+    sprintf(udp_srv_ipaddr_s, "%d.%d.%d.%d", ip_addr.ip_1, ip_addr.ip_2, ip_addr.ip_3, ip_addr.ip_4);
+
     /* Initialise with DHCP, connect, and start up the stack */
     eth.init();
     eth.connect();
@@ -45,28 +484,30 @@ void app_start(int argc, char *argv[])
             tests_pass = 0;
             break;
         }
+        printf("\r\n");
+        printf("MBED: calling socket_api_test_create_destroy()\r\n");
         rc = socket_api_test_create_destroy(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET6);
         tests_pass = tests_pass && rc;
 
+        printf("\r\n");
+        printf("MBED: calling socket_api_test_socket_str2addr()\r\n");
         rc = socket_api_test_socket_str2addr(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET6);
         tests_pass = tests_pass && rc;
-        // Need create/destroy for all subsequent tests
-        // str2addr is required for connect test
+
+        /* Need create/destroy for all subsequent tests */
         if (!tests_pass) break;
 
-        rc = socket_api_test_connect_close(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET6,TEST_SERVER, TEST_PORT0);
+        printf("\r\n");
+        printf("MBED: calling udp_ec_tx_rx_from_test(connect=false) udp test using bind(), sendto(), recv_from() \r\n");
+        rc = udp_ec_tx_rx_from_test(udp_srv_ipaddr_s, port, false, &context);
         tests_pass = tests_pass && rc;
 
-        rc = socket_api_test_echo_client_connected(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, SOCKET_STREAM, true, TEST_SERVER, TEST_PORT0);
+        printf("\r\n");
+        printf("MBED: calling udp_ec_tx_rx_from_test(connect=true) udp test using bind(), connect(), send(), recv() \r\n");
+        rc = udp_ec_tx_rx_from_test(udp_srv_ipaddr_s, port, true, &context);
         tests_pass = tests_pass && rc;
 
-        rc = socket_api_test_echo_client_connected(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, SOCKET_DGRAM, true, TEST_SERVER, TEST_PORT1);
-        tests_pass = tests_pass && rc;
-
-        rc = socket_api_test_echo_client_connected(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, SOCKET_DGRAM, false, TEST_SERVER, TEST_PORT1);
-        tests_pass = tests_pass && rc;
-
-        rc = socket_api_test_echo_server_stream(SOCKET_STACK_LWIP_IPV4, SOCKET_AF_INET4, eth.getIPAddress(), TEST_PORT2);
+        rc = udp_ec_send_shutdown_host_script(udp_srv_ipaddr_s, port);
         tests_pass = tests_pass && rc;
 
     } while (0);

--- a/test/udp_echo_client/udp_echo_client.cpp
+++ b/test/udp_echo_client/udp_echo_client.cpp
@@ -463,7 +463,7 @@ void app_start(int, char**)
         int ip_4;
     } ip_addr = {0, 0, 0, 0};
 
-    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_TIMEOUT(60);
     MBED_HOSTTEST_SELECT(sal_udpserver);
     MBED_HOSTTEST_DESCRIPTION(SalUdpServerTest);
     MBED_HOSTTEST_START("Socket Abstract Layer UDP Connection/Tx/Rx Socket Stream Test");


### PR DESCRIPTION

Hi

Please could you review this PR which includes the following:
- fixed version of udp_echo_client test. This includes a new host test script call sal_udpserver.py which implements a working host side udp server that shuts down gracefully without leaving any python processes around.
- fixed version of tcp_echo_client test. As per the udp case, this includes a new host test script sal_tcpserver.py
- working version of init_api test.
- updated version of tcp_echo_server which removes duplicate testing found in other tests. This is not fully working yet but I will continue to get this working while we can progress the PR code review in parallel.

Note the following:
- the udp_echo_client test currently fails due to bug with returned remote socket port from recv_from(). The bug has already been filed.
- the tcp_echo_client test currently fails due to memory allocation error sending 4096 packets. I imagine this used to work but has stopped working now. I will file a new bug for this.

I propose some additional cleanup work:
- move code from sal/socket_abstract_test.cpp used by tcp_echo_client test into tcp_echo_client.cpp.
- move code from sal/socket_abstract_test.cpp used by ucp_echo_client test into ucp_echo_client.cpp.
- move code from sal/socket_abstract_test.cpp used by tcp_echo_server test into tcp_echo_server.cpp.
- move code from sal/socket_abstract_test.cpp used by init_api test into init_api.cpp.
- remove sal/socket_abstract_test.cpp.

I recommend this for the following reasons: 
- it keeps the code self contained and specific to the needs of the test rather than being more generic (and confusing). IMHO the clarity benefit outweighs the disadvantage of code duplication amongst tests. 
- it make the test more useful to developers learning the code base as some tests indicate how the API is supposed to work (even if there are errors from the tests), showing the programming idioms.
- it removes tests which are repeated in more that one test binary, which doesn't have any additional test coverage benefit.


Best
Simon