### PR TITLE
Update LwIP string literals for C++11 compliance

### DIFF
--- a/sal-stack-lwip/lwip/include/ipv4/lwip/ip_addr.h
+++ b/sal-stack-lwip/lwip/include/ipv4/lwip/ip_addr.h
@@ -210,7 +210,7 @@ u8_t ip4_addr_netmask_valid(u32_t netmask);
 #define ip_addr_islinklocal(addr1) (((addr1)->addr & PP_HTONL(0xffff0000UL)) == PP_HTONL(0xa9fe0000UL))
 
 #define ip_addr_debug_print(debug, ipaddr) \
-  LWIP_DEBUGF(debug, ("%"U16_F".%"U16_F".%"U16_F".%"U16_F,             \
+  LWIP_DEBUGF(debug, ("%" U16_F ".%" U16_F ".%" U16_F ".%" U16_F,             \
                       ipaddr != NULL ? ip4_addr1_16(ipaddr) : 0,       \
                       ipaddr != NULL ? ip4_addr2_16(ipaddr) : 0,       \
                       ipaddr != NULL ? ip4_addr3_16(ipaddr) : 0,       \


### PR DESCRIPTION
Only headers affected, since only headers are used by C++11 source files.

Fixes #39 