### PR TITLE
Handle UDP fragmentation

### DIFF
--- a/source/asynch_socket.c
+++ b/source/asynch_socket.c
@@ -700,6 +700,34 @@ static socket_error_t recv_validate(struct socket *socket, void * buf, size_t *l
     return SOCKET_ERROR_NONE;
 }
 
+static struct pbuf* pbuf_consume(struct pbuf *p, size_t consume, uint32_t free_partial) {
+    do {
+        if (consume <= p->len) {
+            /* advance the payload pointer by the number of bytes copied */
+            p->payload = (char *)p->payload + consume;
+            /* reduce the length by the number of bytes copied */
+            p->len -= consume;
+            /* break out of the loop */
+            consume = 0;
+        }
+        if (p->len == 0 || consume > p->len || (consume == 0 && free_partial)) {
+            struct pbuf *q;
+            q = p->next;
+            /* decrement the number of bytes copied by the length of the buffer */
+            if(consume > p->len)
+                consume -= p->len;
+            /* Free the current pbuf */
+            /* NOTE: This operation is interrupt safe, but not thread safe. */
+            if (q != NULL) {
+                pbuf_ref(q);
+            }
+            pbuf_free(p);
+            p = q;
+        }
+    } while (consume);
+    return p;
+}
+
 static socket_error_t recv_copy_free(struct socket *socket, void * buf,
         size_t *len) {
     struct pbuf *p;
@@ -716,46 +744,19 @@ static socket_error_t recv_copy_free(struct socket *socket, void * buf,
             copied = pbuf_copy_partial(p, buf, *len, 0);
             /* Set the external length to the number of bytes copied */
             *len = copied;
-            while (copied) {
-                if (copied < p->len) {
-                    /* advance the payload pointer by the number of bytes copied */
-                    p->payload = (char *)p->payload + copied;
-                    /* reduce the length by the number of bytes copied */
-                    p->len -= copied;
-                    /* break out of the loop */
-                    copied = 0;
-                } else {
-                    struct pbuf *q;
-                    uint16_t freelen = p->tot_len;
-                    q = p->next;
-                    /* decrement the number of bytes copied by the length of the buffer */
-                    copied -= p->len;
-                    /* Free the current pbuf */
-                    /* NOTE: This operation is interrupt safe, but not thread safe. */
-                    if (q != NULL) {
-                        pbuf_ref(q);
-                    }
-                    socket->rxBufChain = q;
-                    pbuf_free(p);
-                    /* Update the TCP window */
-                    tcp_recved(socket->impl, freelen);
-                    p = q;
-                }
-            }
+            p = pbuf_consume(p, copied, 0);
+            socket->rxBufChain = p;
+            /* Update the TCP window */
+            tcp_recved(socket->impl, copied);
             break;
         }
         case SOCKET_DGRAM: {
-            struct pbuf *q;
-            size_t cplen = ((*len) < (p->len) ? (*len) : (p->len));
+            size_t cplen = ((*len) < (p->tot_len) ? (*len) : (p->tot_len));
             copied = pbuf_copy_partial(p, buf, cplen, 0);
             *len = copied;
-            q = p->next;
-            /* NOTE: This operation is interrupt safe, but not thread safe. */
-            if (q != NULL) {
-                pbuf_ref(q);
-            }
-            socket->rxBufChain = q;
-            pbuf_free(p);
+            /* a single read must always consume the whole UDP packet */
+            p = pbuf_consume(p, p->tot_len, 1); /* free partial */
+            socket->rxBufChain = p;
             break;
         }
         default:


### PR DESCRIPTION
Changes UDP behaviour to inspect the ```struct pbuf::tot_len``` field to establish the size of data available, instead of ```struct pbuf::len```.
```pbuf_consume``` is a new utility API, which frees pbufs that have been copied.

cc @simonqhughes @niklas-arm @bogdanm 