### PR TITLE
Add a Nuvoton metamodule targetDependency

### DIFF
--- a/module.json
+++ b/module.json
@@ -46,10 +46,14 @@
     "k64f": {
       "sal-driver-lwip-k64f-eth": "^1.0.3",
       "sal-iface-eth": "^1.0.0"
+    },
+    "nuvoton" : {
+      "sal-driver-lwip-nuvoton" : "^1.0.0",
+      "sal-iface-eth" : "^1.0.0"
     }
   },
   "testDependencies": {
-    "mbed-drivers": "~0.12.1"
+    "mbed-drivers": "^1.0.0"
   },
   "scripts": {
     "testReporter": [


### PR DESCRIPTION
MCUs providing ethernet on Nuvoton platforms are now supported via the sal-driver-lwip-nuvoton dependency.

Nuvoton targets can be added under the sal-driver-lwip-nuvoton metamodule.

The mbed-drivers test dependency has also been updated to the latest 1.0.0.

cc @bogdanm @hugovincent @mjs-arm @Eric-Yang-China 