### PR TITLE
Change MEM_ALIGNMENT to 8 byte

### DIFF
--- a/sal-stack-lwip/lwipopts.h
+++ b/sal-stack-lwip/lwipopts.h
@@ -55,8 +55,8 @@
 
 #endif // #if NO_SYS == 0
 
-// 32-bit alignment
-#define MEM_ALIGNMENT               4
+// 8-byte alignment to match ARM's ABI
+#define MEM_ALIGNMENT               8
 
 #define PBUF_POOL_SIZE              5
 #define MEMP_NUM_TCP_PCB_LISTEN     4


### PR DESCRIPTION
The ARM ABI requires 8-byte alignment. Change this alignment to 8-byte to match that requirement.

cc @bogdanm @mjs-arm 